### PR TITLE
Fix standalone as-var construct

### DIFF
--- a/querystring_tag/templatetags/querystring_tag.py
+++ b/querystring_tag/templatetags/querystring_tag.py
@@ -57,7 +57,7 @@ class QuerystringTagNode(Node):
         # if the "as" keyword has been used to parameterize the result,
         # capture the target variable name and remove the items from `bits`.
         if "as" in bits:
-            if bits[-2] != "as":
+            if len(bits) < 2 or bits[-2] != "as":
                 raise TemplateSyntaxError(
                     "When using the 'as' option, it must be used at the end of tag, with "
                     "a single 'variable name' value included after the 'as' keyword."
@@ -67,7 +67,7 @@ class QuerystringTagNode(Node):
 
         # if the 'only' or 'discard' options are used, identify all of the
         # 'parameter name' arguments that follow it, and remove them from `bits`
-        if bits[0] in ("only", "discard"):
+        if bits and bits[0] in ("only", "discard"):
             params = tuple(extract_param_names(parser, bits[1:]))
             if bits[0] == "only":
                 kwargs["only"] = params

--- a/querystring_tag/templatetags/tests.py
+++ b/querystring_tag/templatetags/tests.py
@@ -355,14 +355,26 @@ class TestQuerystringTag(SimpleTestCase):
         )
 
     def test_using_as_renders_nothing(self):
-        result = self.render_tag("only 'foo' as qs")
+        result = self.render_tag("as qs")
         self.assertEqual(result, "")
 
     def test_using_as_adds_variable_to_context(self):
+        result = self.render_tag("as qs", add_to_template="{{ qs }}")
+        self.assertEqual(result, "?foo=a&foo=b&foo=c&bar=1&bar=2&bar=3&baz=single-value")
+
+    def test_using_as_without_target_name_results_in_error(self):
+        with self.assertRaises(TemplateSyntaxError):
+            self.render_tag("as")
+
+    def test_using_only_var_as_renders_nothing(self):
+        result = self.render_tag("only 'foo' as qs")
+        self.assertEqual(result, "")
+
+    def test_using_only_var_as_adds_variable_to_context(self):
         result = self.render_tag("only 'foo' as qs", add_to_template="{{ qs }}")
         self.assertEqual(result, "?foo=a&foo=b&foo=c")
 
-    def test_using_as_without_target_name_results_in_error(self):
+    def test_using_only_var_as_without_target_name_results_in_error(self):
         with self.assertRaises(TemplateSyntaxError):
             self.render_tag("only 'foo' as")
 


### PR DESCRIPTION
Allow the tag to be used with only the as-var construct, e.g. `{% querystring as qs %}`.

Fixes: #12 